### PR TITLE
Fix DAC0800 SOIC pinouts

### DIFF
--- a/MusicThingModular.l#2
+++ b/MusicThingModular.l#2
@@ -4605,7 +4605,7 @@ Thonk 108-0044-EVX</description>
 <pad name="1" x="-2.54" y="-2.54" drill="1" diameter="1.4224" rot="R90"/>
 <pad name="COM" x="0" y="-2.54" drill="1" diameter="1.4224" rot="R90"/>
 <pad name="3" x="2.54" y="-2.54" drill="1" diameter="1.4224" rot="R90"/>
-<text x="-4.064" y="2.794" size="1.016" layer="25">&gt;NAME</text>
+<text x="-4.445" y="-4.572" size="1.016" layer="25" rot="R90">&gt;NAME</text>
 <circle x="0" y="0" radius="4" width="0.0508" layer="51"/>
 <pad name="1A" x="-2.54" y="2.54" drill="1" diameter="1.4224" rot="R90"/>
 <pad name="COMA" x="0" y="2.54" drill="1" diameter="1.4224" rot="R90"/>

--- a/MusicThingModular.l#3
+++ b/MusicThingModular.l#3
@@ -7,7 +7,7 @@
 <setting keepoldvectorfont="yes"/>
 <setting verticaltext="up"/>
 </settings>
-<grid distance="1" unitdist="mm" unit="mm" style="lines" multiple="1" display="yes" altdistance="5" altunitdist="mil" altunit="mil"/>
+<grid distance="100" unitdist="mil" unit="mil" style="lines" multiple="1" display="yes" altdistance="5" altunitdist="mil" altunit="mil"/>
 <layers>
 <layer number="1" name="Top" color="4" fill="1" visible="yes" active="yes"/>
 <layer number="2" name="Route2" color="1" fill="3" visible="yes" active="yes"/>
@@ -4589,6 +4589,27 @@ Source: http://www.analog.com/static/imported-files/data_sheets/AD8541_8542_8544
 <hole x="-20.5" y="0" drill="2.1"/>
 <hole x="20.5" y="0" drill="2.1"/>
 <rectangle x1="-18.5" y1="-1.125" x2="18.5" y2="1.125" layer="46"/>
+</package>
+<package name="SUBMINI_TOGGLE_DPDT">
+<description>&lt;b&gt;Submini Toggle&lt;/b&gt;&lt;p&gt;
+Thonk 108-0044-EVX</description>
+<wire x1="-4.1" y1="4.572" x2="4.1" y2="4.572" width="0.127" layer="21"/>
+<wire x1="4.1" y1="4.572" x2="4.1" y2="-4.572" width="0.127" layer="21"/>
+<wire x1="4.1" y1="-4.572" x2="-4.1" y2="-4.572" width="0.127" layer="21"/>
+<wire x1="-4.1" y1="-4.572" x2="-4.1" y2="4.572" width="0.127" layer="21"/>
+<wire x1="-3.175" y1="1.27" x2="0" y2="1.27" width="0.0508" layer="51"/>
+<wire x1="-3.175" y1="-1.27" x2="0" y2="-1.27" width="0.0508" layer="51"/>
+<wire x1="0" y1="1.27" x2="0" y2="-1.27" width="0.0508" layer="51" curve="-180"/>
+<wire x1="-1.375" y1="1.275" x2="-1.35" y2="-1.3" width="0.0508" layer="51" curve="-273.242292"/>
+<circle x="-3.175" y="0" radius="1.27" width="0.0508" layer="51"/>
+<pad name="1" x="-2.54" y="-2.54" drill="1" diameter="1.4224" rot="R90"/>
+<pad name="COM" x="0" y="-2.54" drill="1" diameter="1.4224" rot="R90"/>
+<pad name="3" x="2.54" y="-2.54" drill="1" diameter="1.4224" rot="R90"/>
+<text x="-4.064" y="2.794" size="1.016" layer="25">&gt;NAME</text>
+<circle x="0" y="0" radius="4" width="0.0508" layer="51"/>
+<pad name="1A" x="-2.54" y="2.54" drill="1" diameter="1.4224" rot="R90"/>
+<pad name="COMA" x="0" y="2.54" drill="1" diameter="1.4224" rot="R90"/>
+<pad name="3A" x="2.54" y="2.54" drill="1" diameter="1.4224" rot="R90"/>
 </package>
 </packages>
 <symbols>

--- a/MusicThingModular.l#4
+++ b/MusicThingModular.l#4
@@ -7,7 +7,7 @@
 <setting keepoldvectorfont="yes"/>
 <setting verticaltext="up"/>
 </settings>
-<grid distance="0.1" unitdist="inch" unit="inch" style="lines" multiple="1" display="yes" altdistance="0.01" altunitdist="inch" altunit="inch"/>
+<grid distance="1" unitdist="mm" unit="mm" style="lines" multiple="1" display="yes" altdistance="5" altunitdist="mil" altunit="mil"/>
 <layers>
 <layer number="1" name="Top" color="4" fill="1" visible="yes" active="yes"/>
 <layer number="2" name="Route2" color="1" fill="3" visible="yes" active="yes"/>
@@ -4557,8 +4557,7 @@ Source: http://www.analog.com/static/imported-files/data_sheets/AD8541_8542_8544
 <pad name="3" x="17.5" y="-1.875" drill="1.5"/>
 <wire x1="-22.5" y1="3.96" x2="-22.5" y2="-4" width="0.0254" layer="51"/>
 <wire x1="-22.5" y1="-4" x2="22.5" y2="-4" width="0.0254" layer="51"/>
-<wire x1="22.5" y1="-4" x2="22.5" y2="-3.96" width="0.0254" layer="51"/>
-<wire x1="22.5" y1="-3.96" x2="22.5" y2="3.96" width="0.0254" layer="51"/>
+<wire x1="22.5" y1="-4" x2="22.5" y2="3.96" width="0.0254" layer="51"/>
 <wire x1="22.5" y1="3.96" x2="-22.5" y2="3.96" width="0.0254" layer="51"/>
 <wire x1="-18.3" y1="1.27" x2="18.3" y2="1.27" width="0.2032" layer="21"/>
 <wire x1="18.3" y1="1.27" x2="18.3" y2="-1.27" width="0.2032" layer="21"/>
@@ -4568,6 +4567,14 @@ Source: http://www.analog.com/static/imported-files/data_sheets/AD8541_8542_8544
 <text x="-18" y="-3" size="1.27" layer="27">&gt;VALUE</text>
 <hole x="-12.5" y="0" drill="2"/>
 <hole x="10" y="0" drill="2"/>
+<wire x1="-1" y1="-1.15" x2="-1" y2="1.15" width="0.127" layer="51"/>
+<wire x1="-1" y1="1.15" x2="-12.5" y2="1.15" width="0.127" layer="51"/>
+<wire x1="-12.5" y1="1.15" x2="-12.5" y2="-1.15" width="0.127" layer="51"/>
+<wire x1="-12.5" y1="-1.15" x2="-1" y2="-1.15" width="0.127" layer="51"/>
+<wire x1="1" y1="-1.15" x2="1" y2="1.15" width="0.127" layer="51"/>
+<wire x1="1" y1="1.15" x2="10" y2="1.15" width="0.127" layer="51"/>
+<wire x1="10" y1="1.15" x2="10" y2="-1.15" width="0.127" layer="51"/>
+<wire x1="10" y1="-1.15" x2="1" y2="-1.15" width="0.127" layer="51"/>
 </package>
 <package name="7.1MMPANELHOLE">
 <pad name="P$1" x="0" y="0" drill="6"/>

--- a/MusicThingModular.l#5
+++ b/MusicThingModular.l#5
@@ -7,7 +7,7 @@
 <setting keepoldvectorfont="yes"/>
 <setting verticaltext="up"/>
 </settings>
-<grid distance="0.1" unitdist="inch" unit="inch" style="lines" multiple="1" display="no" altdistance="0.01" altunitdist="inch" altunit="inch"/>
+<grid distance="0.1" unitdist="inch" unit="inch" style="lines" multiple="1" display="yes" altdistance="0.01" altunitdist="inch" altunit="inch"/>
 <layers>
 <layer number="1" name="Top" color="4" fill="1" visible="yes" active="yes"/>
 <layer number="2" name="Route2" color="1" fill="3" visible="yes" active="yes"/>
@@ -55,8 +55,6 @@
 <layer number="54" name="bGND_GNDA" color="1" fill="9" visible="no" active="no"/>
 <layer number="56" name="wert" color="7" fill="1" visible="no" active="no"/>
 <layer number="57" name="tCAD" color="7" fill="1" visible="no" active="no"/>
-<layer number="59" name="tCarbon" color="7" fill="1" visible="no" active="no"/>
-<layer number="60" name="bCarbon" color="7" fill="1" visible="no" active="no"/>
 <layer number="90" name="Modules" color="5" fill="1" visible="no" active="no"/>
 <layer number="91" name="Nets" color="2" fill="1" visible="yes" active="yes"/>
 <layer number="92" name="Busses" color="1" fill="1" visible="yes" active="yes"/>
@@ -80,7 +78,6 @@
 <layer number="110" name="110" color="7" fill="1" visible="no" active="no"/>
 <layer number="111" name="111" color="7" fill="1" visible="no" active="no"/>
 <layer number="112" name="tSilk" color="7" fill="1" visible="no" active="no"/>
-<layer number="113" name="IDFDebug" color="4" fill="1" visible="no" active="no"/>
 <layer number="116" name="Patch_BOT" color="9" fill="4" visible="yes" active="yes"/>
 <layer number="118" name="Rect_Pads" color="7" fill="1" visible="no" active="no"/>
 <layer number="121" name="_tsilk" color="7" fill="1" visible="yes" active="yes"/>
@@ -91,7 +88,6 @@
 <layer number="126" name="_bNames" color="7" fill="1" visible="no" active="no"/>
 <layer number="127" name="_tValues" color="7" fill="1" visible="no" active="no"/>
 <layer number="128" name="_bValues" color="7" fill="1" visible="no" active="no"/>
-<layer number="129" name="Mask" color="7" fill="1" visible="no" active="no"/>
 <layer number="131" name="prix" color="7" fill="1" visible="yes" active="yes"/>
 <layer number="132" name="test" color="7" fill="1" visible="yes" active="yes"/>
 <layer number="144" name="Drill_legend" color="7" fill="1" visible="yes" active="yes"/>
@@ -127,19 +123,11 @@
 <layer number="222" name="222bmp" color="23" fill="1" visible="no" active="no"/>
 <layer number="223" name="223bmp" color="24" fill="1" visible="no" active="no"/>
 <layer number="224" name="224bmp" color="25" fill="1" visible="no" active="no"/>
-<layer number="225" name="225bmp" color="7" fill="1" visible="no" active="no"/>
-<layer number="226" name="226bmp" color="7" fill="1" visible="no" active="no"/>
-<layer number="227" name="227bmp" color="7" fill="1" visible="no" active="no"/>
-<layer number="228" name="228bmp" color="7" fill="1" visible="no" active="no"/>
-<layer number="229" name="229bmp" color="7" fill="1" visible="no" active="no"/>
-<layer number="230" name="230bmp" color="7" fill="1" visible="no" active="no"/>
-<layer number="231" name="231bmp" color="7" fill="1" visible="no" active="no"/>
 <layer number="248" name="Housing" color="7" fill="1" visible="no" active="no"/>
 <layer number="249" name="Edge" color="7" fill="1" visible="no" active="no"/>
 <layer number="250" name="Descript" color="3" fill="1" visible="no" active="no"/>
 <layer number="251" name="SMDround" color="12" fill="11" visible="no" active="no"/>
 <layer number="254" name="cooling" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="255" name="routoute" color="7" fill="1" visible="no" active="no"/>
 </layers>
 <library>
 <description>&lt;B&gt;Music Thing Modular parts library &lt;/b&gt;
@@ -4569,7 +4557,8 @@ Source: http://www.analog.com/static/imported-files/data_sheets/AD8541_8542_8544
 <pad name="3" x="17.5" y="-1.875" drill="1.5"/>
 <wire x1="-22.5" y1="3.96" x2="-22.5" y2="-4" width="0.0254" layer="51"/>
 <wire x1="-22.5" y1="-4" x2="22.5" y2="-4" width="0.0254" layer="51"/>
-<wire x1="22.5" y1="-4" x2="22.5" y2="3.96" width="0.0254" layer="51"/>
+<wire x1="22.5" y1="-4" x2="22.5" y2="-3.96" width="0.0254" layer="51"/>
+<wire x1="22.5" y1="-3.96" x2="22.5" y2="3.96" width="0.0254" layer="51"/>
 <wire x1="22.5" y1="3.96" x2="-22.5" y2="3.96" width="0.0254" layer="51"/>
 <wire x1="-18.3" y1="1.27" x2="18.3" y2="1.27" width="0.2032" layer="21"/>
 <wire x1="18.3" y1="1.27" x2="18.3" y2="-1.27" width="0.2032" layer="21"/>
@@ -4579,14 +4568,6 @@ Source: http://www.analog.com/static/imported-files/data_sheets/AD8541_8542_8544
 <text x="-18" y="-3" size="1.27" layer="27">&gt;VALUE</text>
 <hole x="-12.5" y="0" drill="2"/>
 <hole x="10" y="0" drill="2"/>
-<wire x1="-1" y1="-1.15" x2="-1" y2="1.15" width="0.127" layer="51"/>
-<wire x1="-1" y1="1.15" x2="-12.5" y2="1.15" width="0.127" layer="51"/>
-<wire x1="-12.5" y1="1.15" x2="-12.5" y2="-1.15" width="0.127" layer="51"/>
-<wire x1="-12.5" y1="-1.15" x2="-1" y2="-1.15" width="0.127" layer="51"/>
-<wire x1="1" y1="-1.15" x2="1" y2="1.15" width="0.127" layer="51"/>
-<wire x1="1" y1="1.15" x2="10" y2="1.15" width="0.127" layer="51"/>
-<wire x1="10" y1="1.15" x2="10" y2="-1.15" width="0.127" layer="51"/>
-<wire x1="10" y1="-1.15" x2="1" y2="-1.15" width="0.127" layer="51"/>
 </package>
 <package name="7.1MMPANELHOLE">
 <pad name="P$1" x="0" y="0" drill="6"/>
@@ -4601,27 +4582,6 @@ Source: http://www.analog.com/static/imported-files/data_sheets/AD8541_8542_8544
 <hole x="-20.5" y="0" drill="2.1"/>
 <hole x="20.5" y="0" drill="2.1"/>
 <rectangle x1="-18.5" y1="-1.125" x2="18.5" y2="1.125" layer="46"/>
-</package>
-<package name="SUBMINI_TOGGLE_DPDT">
-<description>&lt;b&gt;Submini Toggle&lt;/b&gt;&lt;p&gt;
-Thonk 108-0044-EVX</description>
-<wire x1="-4.1" y1="4.572" x2="4.1" y2="4.572" width="0.127" layer="21"/>
-<wire x1="4.1" y1="4.572" x2="4.1" y2="-4.572" width="0.127" layer="21"/>
-<wire x1="4.1" y1="-4.572" x2="-4.1" y2="-4.572" width="0.127" layer="21"/>
-<wire x1="-4.1" y1="-4.572" x2="-4.1" y2="4.572" width="0.127" layer="21"/>
-<wire x1="-3.175" y1="1.27" x2="0" y2="1.27" width="0.0508" layer="51"/>
-<wire x1="-3.175" y1="-1.27" x2="0" y2="-1.27" width="0.0508" layer="51"/>
-<wire x1="0" y1="1.27" x2="0" y2="-1.27" width="0.0508" layer="51" curve="-180"/>
-<wire x1="-1.375" y1="1.275" x2="-1.35" y2="-1.3" width="0.0508" layer="51" curve="-273.242292"/>
-<circle x="-3.175" y="0" radius="1.27" width="0.0508" layer="51"/>
-<pad name="1" x="-2.54" y="-2.54" drill="1" diameter="1.4224" rot="R90"/>
-<pad name="COM" x="0" y="-2.54" drill="1" diameter="1.4224" rot="R90"/>
-<pad name="3" x="2.54" y="-2.54" drill="1" diameter="1.4224" rot="R90"/>
-<text x="-4.445" y="-4.572" size="1.016" layer="25" rot="R90">&gt;NAME</text>
-<circle x="0" y="0" radius="4" width="0.0508" layer="51"/>
-<pad name="1A" x="-2.54" y="2.54" drill="1" diameter="1.4224" rot="R90"/>
-<pad name="COMA" x="0" y="2.54" drill="1" diameter="1.4224" rot="R90"/>
-<pad name="3A" x="2.54" y="2.54" drill="1" diameter="1.4224" rot="R90"/>
 </package>
 </packages>
 <symbols>
@@ -5399,38 +5359,6 @@ HEAD</text>
 <pin name="RIGHT" x="5.08" y="0" visible="off" length="short" rot="R180"/>
 <pin name="LEFT" x="5.08" y="-2.54" visible="off" length="short" rot="R180"/>
 <pin name="SLEEVE" x="5.08" y="2.54" visible="off" length="short" rot="R180"/>
-</symbol>
-<symbol name="SWITCH-DPDT">
-<description>&lt;h3&gt;Double-Pole, Double-Throw (DPDT) Switch&lt;/h3&gt;
-&lt;p&gt;Double-pole, double-throw switches.&lt;/p&gt;</description>
-<wire x1="1.27" y1="5.08" x2="-2.286" y2="2.794" width="0.254" layer="94"/>
-<wire x1="-2.286" y1="-4.826" x2="1.27" y2="-2.54" width="0.254" layer="94"/>
-<wire x1="2.54" y1="6.35" x2="2.54" y2="7.62" width="0.254" layer="94"/>
-<wire x1="2.54" y1="7.62" x2="-2.54" y2="7.62" width="0.254" layer="94"/>
-<wire x1="-2.54" y1="7.62" x2="-2.54" y2="3.81" width="0.254" layer="94"/>
-<wire x1="-2.54" y1="1.27" x2="-2.54" y2="-3.81" width="0.254" layer="94"/>
-<wire x1="-2.54" y1="-6.35" x2="-2.54" y2="-10.16" width="0.254" layer="94"/>
-<wire x1="-2.54" y1="-10.16" x2="2.54" y2="-10.16" width="0.254" layer="94"/>
-<wire x1="2.54" y1="-10.16" x2="2.54" y2="-8.89" width="0.254" layer="94"/>
-<wire x1="2.54" y1="-6.35" x2="2.54" y2="-3.81" width="0.254" layer="94"/>
-<wire x1="2.54" y1="3.81" x2="2.54" y2="1.27" width="0.254" layer="94"/>
-<wire x1="0" y1="4.064" x2="0" y2="2.54" width="0.254" layer="94"/>
-<wire x1="0" y1="1.27" x2="0" y2="-1.27" width="0.254" layer="94"/>
-<wire x1="0" y1="-2.54" x2="0" y2="-3.302" width="0.254" layer="94"/>
-<circle x="-2.54" y="2.54" radius="0.3592" width="0.254" layer="94"/>
-<circle x="2.54" y="5.08" radius="0.3592" width="0.254" layer="94"/>
-<circle x="2.54" y="0" radius="0.3592" width="0.254" layer="94"/>
-<circle x="2.54" y="-2.54" radius="0.3592" width="0.254" layer="94"/>
-<circle x="2.54" y="-7.62" radius="0.3592" width="0.254" layer="94"/>
-<circle x="-2.54" y="-5.08" radius="0.3592" width="0.254" layer="94"/>
-<text x="0" y="7.874" size="1.778" layer="95" font="vector" align="bottom-center">&gt;NAME</text>
-<text x="0" y="-10.414" size="1.778" layer="96" font="vector" align="top-center">&gt;VALUE</text>
-<pin name="1" x="5.08" y="5.08" visible="off" length="short" rot="R180"/>
-<pin name="2" x="-5.08" y="2.54" visible="off" length="short"/>
-<pin name="3" x="5.08" y="0" visible="off" length="short" rot="R180"/>
-<pin name="4" x="5.08" y="-2.54" visible="off" length="short" rot="R180"/>
-<pin name="5" x="-5.08" y="-5.08" visible="off" length="short"/>
-<pin name="6" x="5.08" y="-7.62" visible="off" length="short" rot="R180"/>
 </symbol>
 </symbols>
 <devicesets>
@@ -7749,26 +7677,6 @@ BF959 corrected 2008.03.06&lt;br&gt;</description>
 <connect gate="G$1" pin="A" pad="1"/>
 <connect gate="G$1" pin="E" pad="3"/>
 <connect gate="G$1" pin="S" pad="2"/>
-</connects>
-<technologies>
-<technology name=""/>
-</technologies>
-</device>
-</devices>
-</deviceset>
-<deviceset name="SUBMINI_TOGGLE_DPDT">
-<gates>
-<gate name="G$1" symbol="SWITCH-DPDT" x="0" y="0"/>
-</gates>
-<devices>
-<device name="" package="SUBMINI_TOGGLE_DPDT">
-<connects>
-<connect gate="G$1" pin="1" pad="1"/>
-<connect gate="G$1" pin="2" pad="COM"/>
-<connect gate="G$1" pin="3" pad="3"/>
-<connect gate="G$1" pin="4" pad="1A"/>
-<connect gate="G$1" pin="5" pad="COMA"/>
-<connect gate="G$1" pin="6" pad="3A"/>
 </connects>
 <technologies>
 <technology name=""/>

--- a/MusicThingModular.lbr
+++ b/MusicThingModular.lbr
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE eagle SYSTEM "eagle.dtd">
-<eagle version="9.5.2">
+<eagle version="9.6.2">
 <drawing>
 <settings>
 <setting alwaysvectorfont="no"/>
@@ -5724,22 +5724,22 @@ Variants with fatter pads for easier soldering, and the LOCK variant which has 5
 </device>
 <device name="SOIC" package="SO16">
 <connects>
-<connect gate="G$1" pin="B1-MSB" pad="5"/>
-<connect gate="G$1" pin="B2" pad="6"/>
-<connect gate="G$1" pin="B3" pad="7"/>
-<connect gate="G$1" pin="B4" pad="8"/>
-<connect gate="G$1" pin="B5" pad="9"/>
-<connect gate="G$1" pin="B6" pad="10"/>
-<connect gate="G$1" pin="B7" pad="11"/>
-<connect gate="G$1" pin="B8-LSB" pad="12"/>
-<connect gate="G$1" pin="COMP" pad="16"/>
-<connect gate="G$1" pin="IOUT" pad="2"/>
-<connect gate="G$1" pin="IOUTB" pad="4"/>
-<connect gate="G$1" pin="V+" pad="13"/>
-<connect gate="G$1" pin="V-" pad="3"/>
-<connect gate="G$1" pin="VLC" pad="1"/>
-<connect gate="G$1" pin="VREF+" pad="14"/>
-<connect gate="G$1" pin="VREF-" pad="15"/>
+<connect gate="G$1" pin="B1-MSB" pad="9"/>
+<connect gate="G$1" pin="B2" pad="10"/>
+<connect gate="G$1" pin="B3" pad="11"/>
+<connect gate="G$1" pin="B4" pad="12"/>
+<connect gate="G$1" pin="B5" pad="13"/>
+<connect gate="G$1" pin="B6" pad="14"/>
+<connect gate="G$1" pin="B7" pad="15"/>
+<connect gate="G$1" pin="B8-LSB" pad="16"/>
+<connect gate="G$1" pin="COMP" pad="4"/>
+<connect gate="G$1" pin="IOUT" pad="6"/>
+<connect gate="G$1" pin="IOUTB" pad="8"/>
+<connect gate="G$1" pin="V+" pad="1"/>
+<connect gate="G$1" pin="V-" pad="7"/>
+<connect gate="G$1" pin="VLC" pad="5"/>
+<connect gate="G$1" pin="VREF+" pad="2"/>
+<connect gate="G$1" pin="VREF-" pad="3"/>
 </connects>
 <technologies>
 <technology name=""/>


### PR DESCRIPTION
DAC0800 is unusual in that it has different pinouts for the DIP and SOIC packages.
See [datasheet](https://www.ti.com/lit/ds/symlink/dac0800.pdf), page 4

The only meaningful file changes in this PR are to the .lbr file. The other "changes" are Eagle maintaining it's own change history mechanism, which git is unaware of.